### PR TITLE
add `Table` support to exportpy

### DIFF
--- a/nimpy.nim
+++ b/nimpy.nim
@@ -1078,6 +1078,7 @@ proc nimTabToPy[T: Table](t: T): PPyObject =
         else:
             let kk = nimValueToPy(k)
             let ret = pyLib.PyDict_SetItem(result, kk, vv)
+            decref kk
         decRef vv
         if ret != 0:
             cannotSerializeErr($k)

--- a/nimpy.nim
+++ b/nimpy.nim
@@ -346,6 +346,8 @@ type
         PyDict_New*: proc(): PPyObject {.cdecl.}
         PyDict_GetItemString*: proc(o: PPyObject, k: cstring): PPyObject {.cdecl.}
         PyDict_SetItemString*: proc(o: PPyObject, k: cstring, v: PPyObject): cint {.cdecl.}
+        PyDict_GetItem*: proc(o: PPyObject, k: PPyObject): PPyObject {.cdecl.}
+        PyDict_SetItem*: proc(o: PPyObject, k, v: PPyObject): cint {.cdecl.}
 
         PyDealloc*: proc(o: PPyObject) {.nimcall.}
 
@@ -658,6 +660,8 @@ proc loadPyLibFromModule(m: LibHandle): PyLib =
     load PyDict_New
     load PyDict_GetItemString
     load PyDict_SetItemString
+    load PyDict_GetItem
+    load PyDict_SetItem
 
     if pl.pythonVersion == 3:
         pl.PyDealloc = deallocPythonObj[PyTypeObject3]
@@ -974,7 +978,8 @@ iterator arguments(prc: NimNode): tuple[idx: int, name, typ, default: NimNode] =
             inc iParam
 
 proc nimArrToPy[T](s: openarray[T]): PPyObject
-proc nimObjToPy[T](o: T): PPyObject
+proc nimTabToPy[T: Table](t: T): PPyObject
+proc nimObjToPy[T: not Table](o: T): PPyObject
 proc nimTupleToPy[T](o: T): PPyObject
 
 proc refCapsuleDestructor(c: PPyObject) {.cdecl.} =
@@ -1040,10 +1045,12 @@ proc nimValueToPy[T](v: T): PPyObject {.inline.} =
         pyLib.PyBool_FromLong(clong(v))
     elif T is Complex:
         pyLib.Py_BuildValue("D", unsafeAddr v)
-    elif T is object:
+    elif T is not Table and T is object:
         nimObjToPy(v)
     elif T is tuple:
         nimTupleToPy(v)
+    elif T is Table:
+        nimTabToPy(v)
     else:
         unknownTypeCompileError(v)
 
@@ -1062,24 +1069,28 @@ proc PyObject_CallObject(o: PPyObject): PPyObject =
 proc cannotSerializeErr(k: string) =
     raise newException(Exception, "Could not serialize object key: " & k)
 
-proc nimObjToPyIter[T; U; V](result: var T, k: U, v: V) {.inline.} =
-    ## the actual iteration content of `nimObjToPy`
-    ## used to allow  `nimObjToPy` to differentiate between `Table` and other
-    ## objects
-    let vv = nimValueToPy(v)
-    let ret = pyLib.PyDict_SetItemString(result, k, vv)
-    decRef vv
-    if ret != 0:
-      cannotSerializeErr(k)
-
-proc nimObjToPy[T](o: T): PPyObject =
+proc nimTabToPy[T: Table](t: T): PPyObject =
     result = PyObject_CallObject(cast[PPyObject](pyLib.PyDict_Type))
-    when T is Table:
-        for k, v in pairs(o):
-            result.nimObjToPyIter(k, v)
-    else:
-        for k, v in fieldPairs(o):
-            result.nimObjToPyIter(k, v)
+    for k, v in pairs(t):
+        let vv = nimValueToPy(v)
+        when type(k) is string:
+          let ret = pyLib.PyDict_SetItemString(result, k, vv)
+        else:
+          let kk = nimValueToPy(k)
+          let ret = pyLib.PyDict_SetItem(result, kk, vv)
+        decRef vv
+        if ret != 0:
+            cannotSerializeErr($k)
+
+
+proc nimObjToPy[T: not Table](o: T): PPyObject =
+    result = PyObject_CallObject(cast[PPyObject](pyLib.PyDict_Type))
+    for k, v in fieldPairs(o):
+        let vv = nimValueToPy(v)
+        let ret = pyLib.PyDict_SetItemString(result, k, vv)
+        decRef vv
+        if ret != 0:
+            cannotSerializeErr(k)
 
 proc tupleSize[T](): int {.compileTime.} =
     var o: T

--- a/nimpy.nim
+++ b/nimpy.nim
@@ -1074,10 +1074,10 @@ proc nimTabToPy[T: Table](t: T): PPyObject =
     for k, v in pairs(t):
         let vv = nimValueToPy(v)
         when type(k) is string:
-          let ret = pyLib.PyDict_SetItemString(result, k, vv)
+            let ret = pyLib.PyDict_SetItemString(result, k, vv)
         else:
-          let kk = nimValueToPy(k)
-          let ret = pyLib.PyDict_SetItem(result, kk, vv)
+            let kk = nimValueToPy(k)
+            let ret = pyLib.PyDict_SetItem(result, kk, vv)
         decRef vv
         if ret != 0:
             cannotSerializeErr($k)

--- a/tests/nimfrompy.nim
+++ b/tests/nimfrompy.nim
@@ -30,6 +30,11 @@ proc getTable(): Table[string, int] {.exportpy.} =
   result = { "Hello" : 0,
              "SomeKey": 10 }.toTable
 
+proc getIntTable(): Table[int, float] {.exportpy.} =
+  result = { 0 : 1.0,
+             1 : 15.0,
+             10 : 5.0 }.toTable
+
 type
     MyObj = object
         a, b: int

--- a/tests/nimfrompy.nim
+++ b/tests/nimfrompy.nim
@@ -1,5 +1,5 @@
 import ../nimpy
-import algorithm, complex
+import algorithm, complex, tables
 from tpyfromnim import nil
 
 proc greet(name: string): string {.exportpy.} =
@@ -25,6 +25,10 @@ proc complexSeqSqrt(a: seq[Complex]): seq[Complex] {.exportpy.} =
     for i, aa in a: result[i] = sqrt(aa)
 
 proc sumIntsWithCustomName(a, b: int32): int {.exportpy: "sum_ints".} = a + b
+
+proc getTable(): Table[string, int] {.exportpy.} =
+  result = { "Hello" : 0,
+             "SomeKey": 10 }.toTable
 
 type
     MyObj = object

--- a/tests/tnimfrompy.py
+++ b/tests/tnimfrompy.py
@@ -20,6 +20,10 @@ assert(s.sum_ints(3, 4) == 7)
 assert(s.getTable()["Hello"] == 0)
 assert(s.getTable()["SomeKey"] == 10)
 
+assert(s.getIntTable()[0] == 1.0)
+assert(s.getIntTable()[1] == 15.0)
+assert(s.getIntTable()[10] == 5.0)
+
 assert(s.TestType() != None)
 
 assert(s.getMyObj()["a"] == 5)

--- a/tests/tnimfrompy.py
+++ b/tests/tnimfrompy.py
@@ -17,6 +17,9 @@ assert(s.complexSeqSqrt([complex(1, -1), complex(1, 1)]) == [cmath.sqrt(complex(
 
 assert(s.sum_ints(3, 4) == 7)
 
+assert(s.getTable()["Hello"] == 0)
+assert(s.getTable()["SomeKey"] == 10)
+
 assert(s.TestType() != None)
 
 assert(s.getMyObj()["a"] == 5)


### PR DESCRIPTION
I thought it would be handy to support `Table` when exporting to Python as a Python dictionary.

I'm not sure if you wish to have `nimpy` import tables though. Neither if this implementation approach is ideal. Initially I implemented it like:
```nim
proc nimTabToPy[T: Table](t: T): PPyObject
proc nimObjToPy[T: not Table](o: T): PPyObject
```
In `nimValueToPy`:
```nim
    elif T is not Table and T is object:
        nimObjToPy(v)
    elif T is Table:
        nimTabToPy(v)
```
and `nimTabToPy`:
```nim
proc nimTabToPy[T: Table](t: T): PPyObject =
    result = PyObject_CallObject(cast[PPyObject](pyLib.PyDict_Type))
    for k, v in pairs(t):
        let vv = nimValueToPy(v)
        let ret = pyLib.PyDict_SetItemString(result, k, vv)
        decRef vv
        if ret != 0:
            cannotSerializeErr(k)
```
But that screamed too much DRY violation.