### PR TITLE
Add Python dictionary -> Nim Table

### DIFF
--- a/tests/pyfromnim.py
+++ b/tests/pyfromnim.py
@@ -14,5 +14,10 @@ class MyClass(object):
 def test_kwargs(a, b):
     return a - b
 
+def test_dict():
+    a = { "Hello" : 0,
+          "World" : 1,
+          "Yay" : 5 }
+    return a
 import sys
 assert(len(sys.argv) > 0)

--- a/tests/tpyfromnim.nim
+++ b/tests/tpyfromnim.nim
@@ -1,4 +1,5 @@
 import ../nimpy, strutils, os
+import ../nimpy, strutils, os, typetraits, tables, json
 
 proc test*() =
     let py = pyBuiltinsModule()
@@ -68,6 +69,13 @@ proc test*() =
         let x = pfn.test_kwargs(b = 3, a = 1)
 
         doAssert(x.to(int) == -2)
+
+    block: # dict test
+      let pfn = pyImport("pyfromnim")
+      let dict = pfn.test_dict()
+      let nimDict = dict.to(Table[string, int])
+      echo "Nim dict ", nimDict
+      echo type(dict)
 
     block: # serialize char's
         doAssert(py.ord("A").to(char) == 'A')

--- a/tests/tpyfromnim.nim
+++ b/tests/tpyfromnim.nim
@@ -71,11 +71,14 @@ proc test*() =
         doAssert(x.to(int) == -2)
 
     block: # dict test
-      let pfn = pyImport("pyfromnim")
-      let dict = pfn.test_dict()
-      let nimDict = dict.to(Table[string, int])
-      echo "Nim dict ", nimDict
-      echo type(dict)
+        let pfn = pyImport("pyfromnim")
+        let dict = pfn.test_dict()
+        let nimDict = dict.to(Table[string, int])
+
+        doAssert nimDict.len == 3
+        doAssert nimDict["Hello"] == 0
+        doAssert nimDict["World"] == 1
+        doAssert nimDict["Yay"] == 5
 
     block: # serialize char's
         doAssert(py.ord("A").to(char) == 'A')


### PR DESCRIPTION
So this is still somewhat work in progress.

This PR adds support to convert Python dictionaries to:
- [x] homogeneous python dict -> Nim Table
- [ ] ~~heterogeneous** python dict -> Nim's `JsonNode`~~

Conversion of Python objects to `JsonNode`s will be done in a separate PR.