### PR TITLE
Add type name to string conversion failure

### DIFF
--- a/nimpy.nim
+++ b/nimpy.nim
@@ -846,7 +846,10 @@ proc pyObjToNimStr(o: PPyObject, v: var string) =
             pyLib.PyErr_Clear()
             raise newException(Exception, "Can't convert python obj to string")
     else:
-        raise newException(Exception, "Can't convert python obj to string")
+        # Name the type that is unable to be converted.
+        let typ = cast[PyTypeObject]((cast[ptr PyObjectObj](o)).ob_type)
+        let errString = "Can't convert python obj of type '$1' to string"
+        raise newException(Exception, errString % [$typ.tp_name])
 
     v = newString(l)
     if l != 0:

--- a/tests/tpyfromnim.nim
+++ b/tests/tpyfromnim.nim
@@ -73,6 +73,29 @@ proc test*() =
         doAssert(py.ord("A").to(char) == 'A')
         doAssert(py.chr('A').to(string) == "A")
 
+    block: # types without a clear string representation print their type name
+        let o = pyImport("pyfromnim").MyClass()
+
+        # Check for a class that does not have __repr__
+        var excMsg = ""
+        var expectedMsg = "Can't convert python obj of type '$1' to string"
+        try:
+            discard o.to(string)
+        except:
+            excMsg = getCurrentExceptionMsg()
+
+        doAssert(excMsg == expectedMsg % "MyClass")
+
+        # Check against the None type
+        var n = py.None
+        try:
+            discard n.to(string)
+        except:
+            excMsg = getCurrentExceptionMsg()
+            echo $excMsg
+
+        doAssert(excMsg == expectedMsg % "NoneType")
+
 when isMainModule:
     test()
     echo "Test complete!"

--- a/tests/tpyfromnim.nim
+++ b/tests/tpyfromnim.nim
@@ -92,7 +92,6 @@ proc test*() =
             discard n.to(string)
         except:
             excMsg = getCurrentExceptionMsg()
-            echo $excMsg
 
         doAssert(excMsg == expectedMsg % "NoneType")
 


### PR DESCRIPTION
When using nimpy, some of the PyObjects I was trying to stringify were failing.

Just adding the type name to the exception helped highlight what I was doing wrong.