### PR TITLE
Add `toJson` proc to convert Python objects to JsonNodes

### DIFF
--- a/nimpy.nim
+++ b/nimpy.nim
@@ -1,10 +1,7 @@
-import dynlib, macros, ospaths, strutils, complex, strutils, sequtils, typetraits, tables,
+import dynlib, macros, ospaths, strutils, complex, strutils, sequtils, typetraits, tables, json,
     nimpy/[py_types, py_utils]
 
 import nimpy/py_lib as lib
-
-import json
-export json
 
 type
     PyObject* = ref object
@@ -921,4 +918,3 @@ proc dir*(v: PyObject): seq[string] =
 proc pyBuiltinsModule*(): PyObject =
     initPyLibIfNeeded()
     pyImport(if pyLib.pythonVersion == 3: "builtins" else: "__builtin__")
-

--- a/nimpy.nim
+++ b/nimpy.nim
@@ -395,27 +395,27 @@ proc pyObjToNimSeq[T](o: PPyObject, v: var seq[T]) =
         # PyList_GetItem # No DECREF. Returns borrowed ref.
 
 proc pyObjToNimTab[T; U](o: PPyObject, tab: var Table[T, U]) =
-  ## call this either:
-  ## - if you want to check whether T and U are valid types for
-  ##   the python dict (i.e. to check whether all python types
-  ##   are convertible to T and U)
-  ## - you know the python dict conforms to T and U and you wish
-  ##   to get a correct Nim table from that
-  tab = initTable[T, U]()
-  let
-    sz = int(pyLib.PyDict_Size(o))
-    ks = pyLib.PyDict_Keys(o)
-    vs = pyLib.PyDict_Values(o)
-  for i in 0 ..< sz:
-    var
-      k: T
-      v: U
-    pyObjToNim(pyLib.PyList_GetItem(ks, i), k)
-    pyObjToNim(pyLib.PyList_GetItem(vs, i), v)
-    # PyList_GetItem # No DECREF. Returns borrowed ref.
-    tab[k] = v
-  decref ks
-  decref vs
+    ## call this either:
+    ## - if you want to check whether T and U are valid types for
+    ##   the python dict (i.e. to check whether all python types
+    ##   are convertible to T and U)
+    ## - you know the python dict conforms to T and U and you wish
+    ##   to get a correct Nim table from that
+    tab = initTable[T, U]()
+    let
+        sz = int(pyLib.PyDict_Size(o))
+        ks = pyLib.PyDict_Keys(o)
+        vs = pyLib.PyDict_Values(o)
+    for i in 0 ..< sz:
+        var
+            k: T
+            v: U
+        pyObjToNim(pyLib.PyList_GetItem(ks, i), k)
+        pyObjToNim(pyLib.PyList_GetItem(vs, i), v)
+        # PyList_GetItem # No DECREF. Returns borrowed ref.
+        tab[k] = v
+    decref ks
+    decref vs
 
 proc pyObjToNimArray[T, I](o: PPyObject, s: var array[I, T]) =
     # assert(PyList_Check(o) != 0)

--- a/tests/pyfromnim.py
+++ b/tests/pyfromnim.py
@@ -19,5 +19,22 @@ def test_dict():
           "World" : 1,
           "Yay" : 5 }
     return a
+
+def test_dict_json():
+    c = MyClass()
+    a = { "Hello" : 0,
+          "World" : 1,
+          "Yay" : 5.5,
+          5 : 10, # non string key converted to string
+          "Complex" : complex(-1.0, 2.2),
+          "Nested" : {"Dict": 12.7},
+          "Object" : c, # NOTE: only converted to string at the moment!
+          "List" : [1, 2, 3, 4],
+          "ListFloat" : [1.5, 2.2, 3.5, 4.0],
+          "ListMixed" : [1, 2.2, 3, 4.0, complex(-1.5, 2.2)],
+          "Tuple" : (5.5, 10.0) # converted to `JArray` as well
+    }
+    return a
+
 import sys
 assert(len(sys.argv) > 0)

--- a/tests/tpyfromnim.nim
+++ b/tests/tpyfromnim.nim
@@ -1,4 +1,4 @@
-import ../nimpy, ../nimpy/raw_buffers, strutils, os, typetraits, tables, json
+import ../nimpy, ../nimpy/raw_buffers, strutils, os, typetraits, tables
 
 proc test*() =
     let py = pyBuiltinsModule()
@@ -117,6 +117,42 @@ proc test*() =
             excMsg = getCurrentExceptionMsg()
 
         doAssert(excMsg == expectedMsg % "NoneType")
+
+    block: # JSON conversion test
+        let pfn = pyImport("pyfromnim")
+        let dict = pfn.test_dict_json()
+
+        let jsonDict = dict.toJson
+        doAssert jsonDict["Hello"].getInt == 0
+        doAssert jsonDict["World"].getInt == 1
+        doAssert jsonDict["Yay"].getFloat == 5.5
+        doAssert jsonDict["5"].getInt == 10
+        doAssert jsonDict["Complex"] == %* { "real" : -1.0,
+                                             "imag" : 2.2 }
+        doAssert jsonDict["Nested"] == %* { "Dict" : 12.7 }
+        doAssert "pyfromnim.MyClass" in jsonDict["Object"].getStr
+        doAssert jsonDict["List"][0].getInt == 1
+        doAssert jsonDict["List"][1].getInt == 2
+        doAssert jsonDict["List"][2].getInt == 3
+        doAssert jsonDict["List"][3].getInt == 4
+
+        doAssert jsonDict["ListFloat"][0].getFloat == 1.5
+        doAssert jsonDict["ListFloat"][1].getFloat == 2.2
+        doAssert jsonDict["ListFloat"][2].getFloat == 3.5
+        doAssert jsonDict["ListFloat"][3].getFloat == 4.0
+
+        doAssert jsonDict["ListMixed"][0].getInt == 1
+        doAssert jsonDict["ListMixed"][1].getFloat == 2.2
+        doAssert jsonDict["ListMixed"][2].getInt == 3
+        doAssert jsonDict["ListMixed"][3].getFloat == 4.0
+        doAssert jsonDict["ListMixed"][4] == %* { "real" : -1.5,
+                                                  "imag" : 2.2 }
+
+        doAssert jsonDict["Tuple"][0].getFloat == 5.5
+        doAssert jsonDict["Tuple"][1].getFloat == 10.0
+
+
+
 
 when isMainModule:
     test()

--- a/tests/tpyfromnim.nim
+++ b/tests/tpyfromnim.nim
@@ -1,4 +1,4 @@
-import ../nimpy, ../nimpy/raw_buffers, strutils, os, typetraits, tables
+import ../nimpy, ../nimpy/raw_buffers, strutils, os, typetraits, tables, json
 
 proc test*() =
     let py = pyBuiltinsModule()


### PR DESCRIPTION
So, finally spent some time attempting this again. I hope this implementation is more along the lines of what you had in mind. :) I find it much nicer at least, haha.

Conversion of objects to Json isn't really supported though. At least for objects that provide  an iterator, that would make sense however.
The main reason is that I don't quite get how to check whether something is a class object. So the C API way to do `isinstance(obj, type)`. 

And unfortunately I had to put the `items` iterator further up, because iterators seemingly cannot be forward declared? I wanted to use it to avoid a lot of boilerplate in the `%` proc.

Also fixed the indentation level of a proc of the previous PR.

edit: should the `PyBaseType` be moved to `py_types.nim`?