### PR TITLE
Map Python exception to equivalent Nim exception, if possible. Closes #18

### DIFF
--- a/nimpy/py_lib.nim
+++ b/nimpy/py_lib.nim
@@ -258,7 +258,6 @@ proc loadPyLibFromModule(m: LibHandle): PyLib =
     load PyExc_ValueError
     load PyExc_EOFError
     load PyExc_MemoryError
-    load PyExc_LookupError
     load PyExc_IndexError
     load PyExc_KeyError
 
@@ -272,7 +271,6 @@ proc loadPyLibFromModule(m: LibHandle): PyLib =
     pl.PyExc_ValueError = cast[ptr PPyObject](pl.PyExc_ValueError)[]
     pl.PyExc_EOFError = cast[ptr PPyObject](pl.PyExc_EOFError)[]
     pl.PyExc_MemoryError = cast[ptr PPyObject](pl.PyExc_MemoryError)[]
-    pl.PyExc_LookupError = cast[ptr PPyObject](pl.PyExc_LookupError)[]
     pl.PyExc_IndexError = cast[ptr PPyObject](pl.PyExc_IndexError)[]
     pl.PyExc_KeyError = cast[ptr PPyObject](pl.PyExc_KeyError)[]
 

--- a/nimpy/py_lib.nim
+++ b/nimpy/py_lib.nim
@@ -89,6 +89,25 @@ type
         PyErr_Fetch*: proc(ptype, pvalue, ptraceback: ptr PPyObject) {.cdecl.}
         PyErr_NormalizeException*: proc(ptype, pvalue, ptraceback: ptr PPyObject) {.cdecl.}
 
+        PyErr_GivenExceptionMatches*: proc(given, exc: PPyObject): cint {.cdecl.}
+
+        PyExc_BaseException*: PPyObject # should always match any exception?
+        PyExc_Exception*: PPyObject
+        PyExc_ArithmeticError*: PPyObject
+        PyExc_FloatingPointError*: PPyObject
+        PyExc_OverflowError*: PPyObject
+        PyExc_ZeroDivisionError*: PPyObject
+        PyExc_AssertionError*: PPyObject
+        PyExc_OSError*: PPyObject
+        PyExc_IOError*: PPyObject # in Python 3 IOError *is* OSError
+        PyExc_ValueError*: PPyObject
+        PyExc_EOFError*: PPyObject
+        PyExc_MemoryError*: PPyObject
+        PyExc_IndexError*: PPyObject
+        PyExc_KeyError*: PPyObject
+
+
+
 var pyObjectStartOffset*: uint
 var pyLib*: PyLib
 
@@ -227,6 +246,35 @@ proc loadPyLibFromModule(m: LibHandle): PyLib =
 
     load PyErr_Fetch
     load PyErr_NormalizeException
+    load PyErr_GivenExceptionMatches
+
+    load PyExc_ArithmeticError
+    load PyExc_FloatingPointError
+    load PyExc_OverflowError
+    load PyExc_ZeroDivisionError
+    load PyExc_AssertionError
+    load PyExc_OSError
+    load PyExc_IOError
+    load PyExc_ValueError
+    load PyExc_EOFError
+    load PyExc_MemoryError
+    load PyExc_LookupError
+    load PyExc_IndexError
+    load PyExc_KeyError
+
+    pl.PyExc_ArithmeticError = cast[ptr PPyObject](pl.PyExc_ArithmeticError)[]
+    pl.PyExc_FloatingPointError = cast[ptr PPyObject](pl.PyExc_FloatingPointError)[]
+    pl.PyExc_OverflowError = cast[ptr PPyObject](pl.PyExc_OverflowError)[]
+    pl.PyExc_ZeroDivisionError = cast[ptr PPyObject](pl.PyExc_ZeroDivisionError)[]
+    pl.PyExc_AssertionError = cast[ptr PPyObject](pl.PyExc_AssertionError)[]
+    pl.PyExc_OSError = cast[ptr PPyObject](pl.PyExc_OSError)[]
+    pl.PyExc_IOError = cast[ptr PPyObject](pl.PyExc_IOError)[]
+    pl.PyExc_ValueError = cast[ptr PPyObject](pl.PyExc_ValueError)[]
+    pl.PyExc_EOFError = cast[ptr PPyObject](pl.PyExc_EOFError)[]
+    pl.PyExc_MemoryError = cast[ptr PPyObject](pl.PyExc_MemoryError)[]
+    pl.PyExc_LookupError = cast[ptr PPyObject](pl.PyExc_LookupError)[]
+    pl.PyExc_IndexError = cast[ptr PPyObject](pl.PyExc_IndexError)[]
+    pl.PyExc_KeyError = cast[ptr PPyObject](pl.PyExc_KeyError)[]
 
 when defined(windows):
     import winlean

--- a/nimpy/py_types.nim
+++ b/nimpy/py_types.nim
@@ -283,5 +283,24 @@ type
         smalltable*: array[2, Py_ssize_t] # Don't refer! not available in python 3
         internal*: pointer # Don't ever refer
 
-proc isNil*(p: PPyObject): bool {.borrow.}
+    # enum to map Python Exceptions to Nim Exceptions.
+    # the string value corresponds to the Python Exception
+    # while the enum identifier corresponds to the Nim exception (excl. "pe")
+    PythonErrorKind* = enum
+        peOSError = "OSError"
+        peIOError = "IOError"
+        peValueError = "ValueError"
+        peKeyError = "KeyError"
+        peEOFError = "EOFError"
+        peArithmeticError = "ArithmeticError"
+        peDivByZeroError = "ZeroDivisionError"
+        peOverflowError = "OverflowError"
+        peAssertionError = "AssertionError"
+        peOutOfMemError = "MemoryError"
+        peIndexError = "IndexError"
+        peFloatingPointError = "FloatingPointError"
+        peException = "Exception" # general exception, if no equivalent Nim Exception
 
+
+
+proc isNil*(p: PPyObject): bool {.borrow.}

--- a/nimpy/py_types.nim
+++ b/nimpy/py_types.nim
@@ -287,20 +287,19 @@ type
     # the string value corresponds to the Python Exception
     # while the enum identifier corresponds to the Nim exception (excl. "pe")
     PythonErrorKind* = enum
+        peArithmeticError = "ArithmeticError"
+        peFloatingPointError = "FloatingPointError"
+        peOverflowError = "OverflowError"
+        peDivByZeroError = "ZeroDivisionError"
+        peAssertionError = "AssertionError"
         peOSError = "OSError"
         peIOError = "IOError"
         peValueError = "ValueError"
-        peKeyError = "KeyError"
         peEOFError = "EOFError"
-        peArithmeticError = "ArithmeticError"
-        peDivByZeroError = "ZeroDivisionError"
-        peOverflowError = "OverflowError"
-        peAssertionError = "AssertionError"
         peOutOfMemError = "MemoryError"
+        peKeyError = "KeyError"
         peIndexError = "IndexError"
-        peFloatingPointError = "FloatingPointError"
         peException = "Exception" # general exception, if no equivalent Nim Exception
-
 
 
 proc isNil*(p: PPyObject): bool {.borrow.}

--- a/nimpy/py_utils.nim
+++ b/nimpy/py_utils.nim
@@ -55,11 +55,7 @@ proc extractPythonError(typ: string): PythonErrorKind =
   var error = ""
   if scanf(typ, "<class '$*'>", error) or # Python 3
      scanf(typ, "<type 'exceptions.$*'>", error): # Python 2
-    try:
-      result = parseEnum[PythonErrorKind](error)
-    except ValueError:
-      # exception not supported, return general exception
-      result = peException
+    result = parseEnum[PythonErrorKind](error, peException)
   else:
     # else return general exception
     result = peException

--- a/nimpy/py_utils.nim
+++ b/nimpy/py_utils.nim
@@ -113,6 +113,7 @@ macro generateRaiseCase(typ: PPyObject, typns, valns: string): untyped =
     if `pyLib`.`pyVersion` == 3 and `peKind` == `peIOError`:
       # if Py3 and `IOError`, rewrite to `OSError`
       `peKind` = `peOSError`
+
   var caseStmt = nnkCaseStmt.newTree(
     peKind)
   for o in ofBranches:

--- a/nimpy/py_utils.nim
+++ b/nimpy/py_utils.nim
@@ -53,7 +53,8 @@ proc pyStringToNim*(o: PPyObject, output: var string): bool =
 
 proc extractPythonError(typ: string): PythonErrorKind =
   var error = ""
-  if scanf(typ, "<class '$*'>", error):
+  if scanf(typ, "<class '$*'>", error) or # Python 3
+     scanf(typ, "<type 'exceptions.$*'>", error): # Python 2
     try:
       result = parseEnum[PythonErrorKind](error)
     except ValueError:

--- a/nimpy/py_utils.nim
+++ b/nimpy/py_utils.nim
@@ -1,3 +1,5 @@
+import strscans, strutils, macros
+
 import py_lib as lib
 import py_types
 
@@ -49,6 +51,42 @@ proc pyStringToNim*(o: PPyObject, output: var string): bool =
 
     result = true
 
+proc extractPythonError(typ: string): PythonErrorKind =
+  var error = ""
+  if scanf(typ, "<class '$*'>", error):
+    try:
+      result = parseEnum[PythonErrorKind](error)
+    except ValueError:
+      # exception not supported, return general exception
+      result = peException
+  else:
+    # else return general exception
+    result = peException
+
+macro generateRaiseCase(peKind: PythonErrorKind, typns, valns: string): untyped =
+  ## generates a case statement to map Python Exceptions to Nim exception
+  ## case peKind
+  ## of peOSError
+  ##   raise newException(OSError, typns & ": " & valns)
+  ## .. # and so on
+  let peEnumImpl = bindSym("PythonErrorKind").getImpl
+  var ofBranches: seq[NimNode]
+  # iterate enum fields
+  for x in peEnumImpl[2]:
+    if x.kind == nnkEnumFieldDef:
+      # get name and remove "pe" prefix to get Nim Exception
+      let ofExpr = ident(x[0].strVal)
+      var nimExc = x[0].strVal
+      removePrefix(nimExc, "pe")
+      let nimExcIdent = ident(nimExc)
+      let raiseStmt = quote do:
+        raise newException(`nimExcIdent`, `typns` & ": " & `valns`)
+      ofBranches.add nnkOfBranch.newTree(ofExpr, raiseStmt)
+  result = nnkCaseStmt.newTree(
+    peKind)
+  for o in ofBranches:
+    result.add o
+
 proc raisePythonError*() =
     var typ, val, tb: PPyObject
     pyLib.PyErr_Fetch(addr typ, addr val, addr tb)
@@ -60,5 +98,7 @@ proc raisePythonError*() =
       raise newException(Exception, "Can not stringify exception")
     decRef vals
     decRef typs
-    raise newException(Exception, typns & ": " & valns)
-
+    # extract the correct `PythonErrorKind` from the exception's name
+    let peKind = extractPythonError(typns)
+    # and generate the case branches for all exceptions based on it
+    generateRaiseCase(peKind, typns, valns)

--- a/tests/tpyfromnim.nim
+++ b/tests/tpyfromnim.nim
@@ -174,6 +174,7 @@ proc test*() =
         check(pfn.testFloatingPointError, FloatingPointError)
         check(pfn.testException, Exception)
         check(pfn.testUnsupportedException, Exception)
+        check(pfn.testCustomException, IndexError)
 
 
 when isMainModule:

--- a/tests/tpyfromnim.nim
+++ b/tests/tpyfromnim.nim
@@ -151,7 +151,29 @@ proc test*() =
         doAssert jsonDict["Tuple"][0].getFloat == 5.5
         doAssert jsonDict["Tuple"][1].getFloat == 10.0
 
+    block: # test mapping of exceptions
+        let pfn = pyImport("traise")
+        template check(f: untyped, exc: varargs[untyped]): untyped =
+            try:
+              discard f()
+            except exc:
+              discard
 
+        check(pfn.testOSError, OSError)
+        # in python3 IOError == OSError
+        check(pfn.testIOError, IOError, OSError)
+        check(pfn.testValueError, ValueError)
+        check(pfn.testKeyError, KeyError)
+        check(pfn.testEOFError, EOFError)
+        check(pfn.testArithmeticError,ArithmeticError)
+        check(pfn.testZeroDivisionError, DivByZeroError)
+        check(pfn.testOverflowError, OverflowError)
+        check(pfn.testAssertionError, AssertionError)
+        check(pfn.testMemoryError, OutOfMemError)
+        check(pfn.testIndexError, IndexError)
+        check(pfn.testFloatingPointError, FloatingPointError)
+        check(pfn.testException, Exception)
+        check(pfn.testUnsupportedException, Exception)
 
 
 when isMainModule:

--- a/tests/traise.py
+++ b/tests/traise.py
@@ -1,0 +1,44 @@
+# raise all mapped exceptions in Python
+
+def testOSError():
+    raise(OSError)
+
+def testIOError():
+    raise(IOError)
+
+def testValueError():
+    raise(ValueError)
+
+def testKeyError():
+    raise(KeyError)
+
+def testEOFError():
+    raise(EOFError)
+
+def testArithmeticError():
+    raise(ArithmeticError)
+
+def testZeroDivisionError():
+    raise(ZeroDivisionError)
+
+def testOverflowError():
+    raise(OverflowError)
+
+def testAssertionError():
+    raise(AssertionError)
+
+def testMemoryError():
+    raise(MemoryError)
+
+def testIndexError():
+    raise(IndexError)
+
+def testFloatingPointError():
+    raise(FloatingPointError)
+
+def testException():
+    raise(Exception)
+
+def testUnsupportedException():
+    # example for an unsupported Python exception
+    raise(NotImplementedError)

--- a/tests/traise.py
+++ b/tests/traise.py
@@ -42,3 +42,8 @@ def testException():
 def testUnsupportedException():
     # example for an unsupported Python exception
     raise(NotImplementedError)
+
+def testCustomException():
+    class TestException(IndexError):
+        pass
+    raise(TestException)


### PR DESCRIPTION
This is an attempt to introduce mapping Python exceptions to equivalent Nim exception, if an equivalent exists. If not a generic `Exception` is raised.

I decided to define an `enum` for supported Python exceptions, which contain the name of the exception in Python as a string value. The name of the field is the name of the corresponding Nim exception plus a "pe" prefix. This way we can construct the case statement with a macro.

I'm not sure if:
- I'm missing some exceptions that can be mapped / may have wrongly mapped some
- if `ZeroDivisionError` should rather be mapped to `FloatDivByZeroError` instead of `DivByZeroError`

Fixes #18.