### PR TITLE
Improvements and fixes

### DIFF
--- a/nimpy.nim
+++ b/nimpy.nim
@@ -977,10 +977,12 @@ const
     includeFolderError = includeFolder.exitCode
     includeFolderStr = includeFolder.output
 when includeFolderError == 0:
-    {.passC: "-I" & includeFolderStr .}
-    const canUsePythonHeader = true
+    # do this only on unix systems for now, sorry windows users but this needs a windows shell version
+    when not defined(windows):
+        const hasPythonHeader* = staticExec("[ -f '" & includeFolderStr & "/Python.h" & "' ] && echo 'true' || echo 'false'") == "true"
+        {.passC: "-I" & includeFolderStr .}
 
-when declared canUsePythonHeader:
+when declared(hasPythonHeader) and hasPythonHeader:
     defineCppType(PyThreadState, "PyThreadState", "<Python.h>")
 
     var pyThread {.threadvar.}: ptr PyThreadState

--- a/nimpy.nim
+++ b/nimpy.nim
@@ -1157,10 +1157,11 @@ proc initPyLib() =
 
     Py_InitializeEx(0)
 
+    # according to python docs, when 0 is passed as argc, an empty string is prepended to sys.path, 
+    # which is the same as prepending the current working directory (".").
     let PySys_SetArgvEx = cast[proc(argc: cint, argv: pointer, updatepath: cint){.cdecl.}](m.symAddr("PySys_SetArgvEx"))
     if not PySys_SetArgvEx.isNil:
-        var args = [cstring(""), nil]
-        PySys_SetArgvEx(1, cast[pointer](addr args[0]), 0)
+        PySys_SetArgvEx(0, nil, 0)
 
     pyLib = loadPyLibFromModule(m)
 

--- a/nimpy.nim
+++ b/nimpy.nim
@@ -315,7 +315,7 @@ proc pyObjToNimTuple(o: PPyObject, vv: var tuple) =
 proc finalizePyObject(o: PyObject) =
     decRef o.rawPyObj
 
-proc newPyObjectConsumingRef(o: PPyObject): PyObject =
+proc newPyObjectConsumingRef(o: PPyObject): PyObject {.discardable.} =
     assert(not o.isNil, "internal error")
     result.new(finalizePyObject)
     result.rawPyObj = o

--- a/nimpy.nimble
+++ b/nimpy.nimble
@@ -8,6 +8,7 @@ license       = "MIT"
 # Dependencies
 
 requires "nim >= 0.17.0"
+requires "fragments >= 0.1.22"
 
 import oswalkdir, ospaths, strutils
 


### PR DESCRIPTION
* make `newPyObjectConsumingRef` `discardable` so to improve usability (not sure if that's in your vision tho)
* fixed some weird crash related to "call stack is not deep enough" python error, it's a bit of a hack and required our fragments cpp ffi framework to easy interop with python.h header (if header is not found does nothing), this change allows modules like *pandas* to fully work.

We are using nimpy a lot lately with nimtorch actually, and I like it a lot. Thank you @yglukhov 
If you think those changes are a bit intrusive no problem, but I figure the community might use this branch!

Adding fragments cpp ffi magic adds the possibility to directly use python headers, this should help in the future I think!