### PR TITLE
removed parenthesis around assert

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ nim c --threads:on --app:lib --out:mymodule.so mymodule
 ```py
 # test.py
 import mymodule
-assert(mymodule.greet("world") == "Hello, world!")
-assert(mymodule.greet(name="world") == "Hello, world!")
+assert mymodule.greet("world") == "Hello, world!"
+assert mymodule.greet(name="world") == "Hello, world!"
 ```
 
 ## Calling python from nim
@@ -34,7 +34,7 @@ echo "Current dir is: ", os.getcwd().to(string)
 # sum(range(1, 5))
 let py = pyBuiltinsModule()
 let s = py.sum(py.range(0, 5)).to(int)
-assert(s == 10)
+assert s == 10
 ```
 Note: here nimpy relies on your local python installation.
 


### PR DESCRIPTION
assert is not a function in Python
see [here](https://stackoverflow.com/questions/3112171/python-assert-with-and-without-parenthesis) for some potential pitfalls