### PR TITLE
Make pyexport work on Nim executables.

### DIFF
--- a/nimpy.nim
+++ b/nimpy.nim
@@ -313,6 +313,7 @@ proc initModule3(m: var PyModuleDesc): PPyObject =
 
 template declarePyModuleIfNeededAux(name, doc: static[cstring]) =
   when not declared(gPythonLocalModuleDesc):
+    exportedModuleNames.add(name) # in py_lib.nim
     var gPythonLocalModuleDesc {.inject.}: PyModuleDesc
     initPythonModuleDesc(gPythonLocalModuleDesc, name, doc)
     {.push stackTrace: off.}

--- a/tests/builtinpyfromnim.py
+++ b/tests/builtinpyfromnim.py
@@ -1,0 +1,15 @@
+import sys
+
+import tbuiltinpyfromnim as s
+assert(s.__name__ == "tbuiltinpyfromnim")
+
+assert(s.greet_from_exe("world") == "Hello, world!")
+assert(s.greet_from_exe.__doc__ == "This is the docstring")
+
+x = 42
+
+import other_module
+assert(other_module.__name__ == "other_module")
+assert(other_module.__doc__ == "Other module docstring")
+assert(other_module.other_proc() == 9)
+assert(other_module.other_proc.__doc__ == "Other proc docstring")

--- a/tests/modules/other_module.nim
+++ b/tests/modules/other_module.nim
@@ -1,0 +1,8 @@
+# Extra module to test exporting multiple modules from Nim
+import ../../nimpy
+
+pyExportModule("other_module", doc="Other module docstring")
+
+proc other_proc(): int {.exportpy.} =
+  ## Other proc docstring
+  result = 9

--- a/tests/tbuiltinpyfromnim.nim
+++ b/tests/tbuiltinpyfromnim.nim
@@ -1,0 +1,14 @@
+import ../nimpy
+import os
+import modules/other_module
+
+proc greet_from_exe(name: string): string {.exportpy.} =
+  ## This is the docstring
+  return "Hello, " & name & "!"
+
+# Make sure Python can find builtinpyfromnim.py
+let sys = pyImport("sys")
+discard sys.path.append(currentSourcePath.parentDir)
+
+let pytest {.used.} = pyImport("builtinpyfromnim")
+assert(pytest.x.to(int) == 42)


### PR DESCRIPTION
Works on Python2/Python3.

Updated test cases included.

Part of #139