### PR TITLE
Testing updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 nimcache/
 tests/__pycache__/
 tests/tpyfromnim
+tests/tbuiltinpyfromnim
 *.pyc
+*.pyd
 *.so

--- a/nimpy.nimble
+++ b/nimpy.nimble
@@ -51,7 +51,14 @@ proc runTests(nimFlags = "") =
     if sf.ext == ".nim" and not sf.name.startsWith("t"):
       exec "nim c --threads:on --app:lib " & nimFlags & " --out:" & f.path.changeFileExt(pluginExtension) & " " & f.path
 
-  mvFile("tests/custommodulename".changeFileExt(pluginExtension), "tests/_mycustommodulename".changeFileExt(pluginExtension))
+  let
+    sourceFile = "tests/custommodulename".changeFileExt(pluginExtension)
+    targetFile = "tests/_mycustommodulename".changeFileExt(pluginExtension)
+  try:
+    rmFile(targetFile)
+  except:
+    discard
+  mvFile(sourceFile, targetFile)
 
   let
     pythonExes = calcPythonExecutables()

--- a/nimpy.nimble
+++ b/nimpy.nimble
@@ -9,6 +9,24 @@ requires "nim >= 0.17.0"
 
 import oswalkdir, os, strutils
 
+proc calcPythonExecutables() : seq[string] =
+  ## Calculates which Python executables to use for testing
+  ## The default is to use "python2" and "python3"
+  ##
+  ## You can override this by setting the environment
+  ## variable `NIMPY_PY_EXES` to a comma separated list
+  ## of Python executables to invoke. For example, to test
+  ## with Python 2 from the system PATH and multiple versions
+  ## of Python 3, you might invoke something like
+  ##
+  ## `NIMPY_PY_EXES="python2,/usr/local/bin/python3.7,/usr/local/bin/python3.8" nimble test`
+  ##
+  ## These are launched via a shell so they can be scripts
+  ## as well as actual Python executables
+
+  let pyExes = getEnv("NIMPY_PY_EXES", "python2,python3")
+  result = pyExes.split(",")
+
 proc runTests(nimFlags = "") =
   let pluginExtension = when defined(windows): "pyd" else: "so"
 
@@ -20,12 +38,14 @@ proc runTests(nimFlags = "") =
 
   mvFile("tests/custommodulename".changeFileExt(pluginExtension), "tests/_mycustommodulename".changeFileExt(pluginExtension))
 
+  let pythonExes = calcPythonExecutables()
   for f in oswalkdir.walkDir("tests"):
     # Run all python modules starting with "t"
     let sf = f.path.splitFile()
     if sf.ext == ".py" and sf.name.startsWith("t"):
-      exec "python2 " & f.path
-      exec "python3 " & f.path
+      for pythonExe in pythonExes:
+        echo "Testing Python executable: ", pythonExe
+        exec pythonExe & " " & f.path
 
   for f in oswalkdir.walkDir("tests"):
     # Run all nim modules starting with "t"

--- a/nimpy.nimble
+++ b/nimpy.nimble
@@ -77,7 +77,7 @@ proc runTests(nimFlags = "") =
     let sf = f.path.splitFile()
     if sf.ext == ".nim" and sf.name.startsWith("t"):
       for libPython in libPythons:
-        exec "nim c -d:nimpytest -d:TEST_LIB_PYTHON=" & libPython & " -r " & nimFlags & " " & f.path
+        exec "nim c -d:TEST_LIB_PYTHON=" & libPython & " -r " & nimFlags & " " & f.path
 
 task test, "Run tests":
   runTests()

--- a/nimpy/py_lib.nim
+++ b/nimpy/py_lib.nim
@@ -466,13 +466,12 @@ proc pyInitLibPath*(pythonLibraryPath: string) =
     raise newException(Exception, "Could not load libpython. Tried " & pythonLibraryPath)
   initPyLib(m)
 
-when defined(nimpy_test):
-  # Hook for overriding which libpython to use for tests
-  const TEST_LIB_PYTHON {.strdefine.} = ""
+# Hook for overriding which libpython to use for tests
+const TEST_LIB_PYTHON {.strdefine.} = ""
 
 proc initPyThreadFrame() =
-  when defined(nimpy_test):
-    if unlikely pyLib.isNil and TEST_LIB_PYTHON != "":
+  when TEST_LIB_PYTHON.len() != 0:
+    if unlikely pyLib.isNil:
       echo "Testing libpython: ", TEST_LIB_PYTHON
       pyInitLibPath(TEST_LIB_PYTHON)
 

--- a/nimpy/py_lib.nim
+++ b/nimpy/py_lib.nim
@@ -466,7 +466,16 @@ proc pyInitLibPath*(pythonLibraryPath: string) =
     raise newException(Exception, "Could not load libpython. Tried " & pythonLibraryPath)
   initPyLib(m)
 
+when defined(nimpy_test):
+  # Hook for overriding which libpython to use for tests
+  const TEST_LIB_PYTHON {.strdefine.} = ""
+
 proc initPyThreadFrame() =
+  when defined(nimpy_test):
+    if unlikely pyLib.isNil and TEST_LIB_PYTHON != "":
+      echo "Testing libpython: ", TEST_LIB_PYTHON
+      pyInitLibPath(TEST_LIB_PYTHON)
+
   # https://stackoverflow.com/questions/42974139/valueerror-call-stack-is-not-deep-enough-when-calling-ipython-embed-method
   # needed for eval and stuff like pandas.query() otherwise crash (call stack is not deep enough)
   if unlikely pyLib.isNil:


### PR DESCRIPTION
A few minor updates for running the tests.   

The main one allows overriding which python executables and libpythons to use for testing.  This continues defaulting to how the tests worked before though. 

This also addresses a minor issue when running the tests on Windows where the tests would fail if the compiled code already existed. 