### PR TITLE
auto convert JsonNode to Python dictionary, fixes #147

### DIFF
--- a/nimpy.nim
+++ b/nimpy.nim
@@ -665,6 +665,7 @@ proc nimArrToPy[T](s: openarray[T]): PPyObject =
   for i in 0 ..< sz:
     let o = nimValueToPy(s[i])
     discard pyLib.PyList_SetItem(result, i, o)
+    # No decRef here. PyList_SetItem "steals" the reference to `o`
 
 proc baseType(o: PPyObject): PyBaseType =
   # returns the correct PyBaseType of the given PyObject extracted
@@ -821,6 +822,7 @@ proc nimJsonToPy(node: JsonNode): PPyObject =
     for i in 0 ..< node.len:
       let o = nimJsonToPy(node[i])
       discard pyLib.PyList_SetItem(result, i, o)
+      # No decRef here. PyList_SetItem "steals" the reference to `o`
   of JObject:
     result = PyObject_CallObject(cast[PPyObject](pyLib.PyDict_Type))
     for k, v in node:

--- a/tests/nimfrompy.nim
+++ b/tests/nimfrompy.nim
@@ -53,6 +53,13 @@ proc getIntTable(): Table[int, float] {.exportpy.} =
        1 : 15.0,
        10 : 5.0 }.toTable
 
+proc getJsonAsDict(): JsonNode {.exportpy.} =
+  result = %* { "SomeKey" : 1.0,
+                "Another" : 5,
+                "Foo" : [1, 2, 3.5, {"InArray" : 5}],
+                "Bar" : { "Nested" : "Value" }
+              }
+
 type
   MyObj = object
     a, b: int

--- a/tests/tnimfrompy.py
+++ b/tests/tnimfrompy.py
@@ -65,6 +65,12 @@ assert(s.getIntTable()[0] == 1.0)
 assert(s.getIntTable()[1] == 15.0)
 assert(s.getIntTable()[10] == 5.0)
 
+dictFromJson = s.getJsonAsDict()
+assert(dictFromJson["SomeKey"] == 1.0)
+assert(dictFromJson["Another"] == 5)
+assert(dictFromJson["Foo"] == [1, 2, 3.5, {"InArray" : 5}])
+assert(dictFromJson["Bar"] == { "Nested" : "Value" })
+
 assert(s.TestType() is not None)
 
 assert(s.getMyObj()["a"] == 5)


### PR DESCRIPTION
This fixes issue #147.

I'm not sure if this is what we want to do by default. @yglukhov you decide that. :)