### PR TITLE
add API procs, check if PyObject has PyBool_type / is PyNone

### DIFF
--- a/tests/pyfromnim.py
+++ b/tests/pyfromnim.py
@@ -42,5 +42,17 @@ def call_callback(fn):
 def concat_strings(a, b):
   return a + b
 
+def test_bool_true():
+  return True
+
+def test_bool_false():
+  return False
+
+def test_none():
+  return None
+
+def test_zero():
+  return 0
+
 import sys
 assert(len(sys.argv) > 0)

--- a/tests/tpyfromnim.nim
+++ b/tests/tpyfromnim.nim
@@ -123,6 +123,21 @@ proc test*() {.gcsafe.} =
 
     doAssert(excMsg == expectedMsg % "NoneType")
 
+  block: # recognize True/False/None
+    let pfn = pyImport("pyfromnim")
+    let t = pfn.test_bool_true()
+    let f = pfn.test_bool_false()
+    let n = pfn.test_none()
+    let z = pfn.test_zero()
+    doAssert t.checkPyBool
+    doAssert f.checkPyBool
+    doAssert not n.checkPyBool
+    doASsert not z.checkPyBool
+    doAssert not t.isPyNone
+    doAssert not f.isPyNone
+    doAssert n.isPyNone
+    doAssert not z.isPyNone
+
   block: # JSON conversion test
     let pfn = pyImport("pyfromnim")
     let dict = pfn.test_dict_json()


### PR DESCRIPTION
The proc name `checkPyBool` was chosen as equivalent to the macro PyBool_Check in the Python C API
but since there is not PyNone_Check, I used `isPyNone` for the function checking if an object is PyNone