### PR TITLE
fix #172 raise on object has no attribute

### DIFF
--- a/nimpy.nim
+++ b/nimpy.nim
@@ -1263,6 +1263,9 @@ proc getAttr*(o: PyObject, name: cstring): PyObject =
   let r = pyLib.PyObject_GetAttrString(o.rawPyObj, name)
   if not r.isNil:
     result = newPyObjectConsumingRef(r)
+  else:
+    # TODO: use `AttributeError` instead of `Exception`, or at least some `PyError`
+    raise newException(Exception, "object has no attribute: " & $name)
 
 proc getProperty*(o: PyObject, name: cstring): PyObject {.deprecated, inline.} = getAttr(o, name)
 

--- a/nimpy.nim
+++ b/nimpy.nim
@@ -1261,11 +1261,11 @@ proc callMethod*(o: PyObject, ResultType: typedesc, name: cstring, args: varargs
 
 proc getAttr*(o: PyObject, name: cstring): PyObject =
   let r = pyLib.PyObject_GetAttrString(o.rawPyObj, name)
-  if not r.isNil:
-    result = newPyObjectConsumingRef(r)
+  if unlikely r.isNil:
+    raisePythonError()
+    # this would cause corruptions with try/except: raise newException(Exception, "object has no attribute: " & $name)
   else:
-    # TODO: use `AttributeError` instead of `Exception`, or at least some `PyError`
-    raise newException(Exception, "object has no attribute: " & $name)
+    result = newPyObjectConsumingRef(r)
 
 proc getProperty*(o: PyObject, name: cstring): PyObject {.deprecated, inline.} = getAttr(o, name)
 


### PR DESCRIPTION
fix #172

before PR:
`getAttr` (or calling via `.`) doesn't raise when accessing non existant attribute, causing memory corruption in subsequent code

after PR:
it raises, and doesn't cause subsequent corruptions, and also is safe to use within try/except:
```nim
when true: # D20200930T200611
  import pkg/nimpy
  let boto3 = pyImport "boto3"
  let session = boto3.Session()
  echo session.get_credentials().access_key
  try:
    let z = session.get_credentials().nonexistant # raises
    echo z == nil # doesn't go here
  except:
    echo "caught" # goes here
  echo session.get_credentials().access_key # calls here correctly
```

## note
also seems more consistant with other parts of code eg:
```nim
proc callObject*(o: PyObject, args: varargs[PPyObject, toPyObjectArgument]): PyObject {.inline.} =
  let res = callObjectAux(o.rawPyObj, args)
  if unlikely res.isNil: raisePythonError()
  newPyObjectConsumingRef(res)
```
