### PR TITLE
fix for https://github.com/nim-lang/Nim/pull/15545

### DIFF
--- a/nimpy.nim
+++ b/nimpy.nim
@@ -843,6 +843,8 @@ proc nimJsonToPy(node: JsonNode): PPyObject =
       decRef vv
       if ret != 0:
         cannotSerializeErr(k)
+  else:
+    doAssert false, "not yet implemented, pending https://github.com/nim-lang/Nim/pull/15545"
 
 # Enum handling
 proc nimpyEnumConvert*[T](o: T): int=


### PR DESCRIPTION
fix for https://github.com/nim-lang/Nim/pull/15545 ; it's the only important_package that was broken under https://github.com/nim-lang/Nim/pull/15545

trailing else was implemented here: https://github.com/nim-lang/Nim/pull/14190