### PR TITLE
Add dotOperators experimentals to tests

### DIFF
--- a/tests/nimfrompy.nim
+++ b/tests/nimfrompy.nim
@@ -95,6 +95,8 @@ proc validateNilObj(o: MyRefObj): bool {.exportpy.} = o.isNil
 proc voidProc() {.exportpy.} =
   discard
 
+{.experimental: "dotOperators".}
+
 proc someFunc1(o: PyObject): PyObject {.exportpy.} = o.sum(o.range(1, 5))
 proc someFunc2(o: PyObject): int {.exportpy.} =
   o.callMethod(int, "sum", o.callMethod("range", 1, 5))

--- a/tests/tbuiltinpyfromnim.nim
+++ b/tests/tbuiltinpyfromnim.nim
@@ -2,6 +2,8 @@ import ../nimpy
 import os
 import modules/other_module
 
+{.experimental: "dotOperators".}
+
 proc greet_from_exe(name: string): string {.exportpy.} =
   ## This is the docstring
   return "Hello, " & name & "!"

--- a/tests/tpyfromnim.nim
+++ b/tests/tpyfromnim.nim
@@ -1,5 +1,7 @@
 import ../nimpy, ../nimpy/raw_buffers, strutils, os, typetraits, tables, json
 
+{.experimental: "dotOperators".}
+
 proc test*() {.gcsafe.} =
   let py = pyBuiltinsModule()
   let s = py.sum(py.range(0, 5)).to(int)


### PR DESCRIPTION
In current Nim you only need the experimental switches for dot/call operators in order to declare them, not to use them. This is changed in https://github.com/nim-lang/Nim/pull/16924, where you need it to use them and not necessarily declare them, and since this package is tested in Nim CI, these tests fail for that PR. The tests have been changed so they are compatible with the PR, but they are also compatible with older versions.