### PR TITLE
fix #216: named tuples can be passed as dict kwargs params

### DIFF
--- a/nimpy.nim
+++ b/nimpy.nim
@@ -973,12 +973,15 @@ proc nimEnumToPy[T](o: T): PPyObject =
   nimpyEnumValue(nimpyEnumConvert(o))
 
 proc nimTupleToPy[T](o: T): PPyObject =
-  const sz = tupleSize[T]()
-  result = pyLib.PyTuple_new(sz)
-  var i = 0
-  for f in fields(o):
-    discard pyLib.PyTuple_SetItem(result, i, nimValueToPy(f))
-    inc i
+  when isNamedTuple(T):
+    nimObjToPy(o)
+  else:
+    const sz = tupleSize[T]()
+    result = pyLib.PyTuple_new(sz)
+    var i = 0
+    for f in fields(o):
+      discard pyLib.PyTuple_SetItem(result, i, nimValueToPy(f))
+      inc i
 
 proc getPyArg(argTuple, argDict: PPyObject, argIdx: int, argName: cstring): PPyObject =
   # argTuple can never be nil


### PR DESCRIPTION
fix #216

after PR this now works:
```nim
s3.generate_presigned_url("get_object", Params=(Bucket: bucket_name, Key: object_name))
```
and this too:
```nim
let dict = toPyObjectArgument (Bucket: bucket_name, Key: object_name)
s3.generate_presigned_url("get_object", Params = dict)
```

