### PR TITLE
Support PyRun_SimpleFile and PyRun_SimpleString

### DIFF
--- a/nimpy.nim
+++ b/nimpy.nim
@@ -1471,6 +1471,16 @@ proc `[]`*[K](o: PyObject, idx: K): PyObject =
 proc `[]=`*[K, V](o: PyObject, idx: K, val: V) =
   o.setElemAtIndex(toPyObjectArgument(idx), toPyObjectArgument(val))
 
+proc pyRunSimpleFile*(fileName: string): int =
+  initPyLibIfNeeded()
+  var fp = open(fileName, fmRead)
+  defer: fp.close()
+  pyLib.PyRun_SimpleFile(fp, fileName)
+
+proc pyRunSimpleString*(command: string): int =
+  initPyLibIfNeeded()
+  pyLib.PyRun_SimpleString(command)
+
 proc pyImport*(moduleName: cstring): PyObject =
   initPyLibIfNeeded()
   let o = pyLib.PyImport_ImportModule(moduleName)

--- a/nimpy/py_lib.nim
+++ b/nimpy/py_lib.nim
@@ -94,6 +94,9 @@ type
     PyCapsule_New*: proc(p: pointer, name: cstring, destr: proc(o: PPyObject) {.pyfunc.}): PPyObject {.pyfunc.}
     PyCapsule_GetPointer*: proc(c: PPyObject, name: cstring): pointer {.pyfunc.}
 
+    PyRun_SimpleFile*: proc(fp: File, filename: cstring): cint {.pyfunc.}
+    PyRun_SimpleString*: proc(command: cstring): cint {.pyfunc.}
+
     PyImport_ImportModule*: proc(name: cstring): PPyObject {.pyfunc.}
     PyEval_GetBuiltins*: proc(): PPyObject {.pyfunc.}
     PyEval_GetGlobals*: proc(): PPyObject {.pyfunc.}
@@ -292,6 +295,9 @@ proc loadPyLibFromModule(m: LibHandle): PyLib =
 
   load PyCapsule_New
   load PyCapsule_GetPointer
+
+  load PyRun_SimpleFile
+  load PyRun_SimpleString
 
   load PyImport_ImportModule
   load PyEval_GetBuiltins

--- a/tests/pyrunfile.py
+++ b/tests/pyrunfile.py
@@ -1,0 +1,4 @@
+import sys
+
+if __name__ == "__main__":
+  print("In pyrunfile.py main")

--- a/tests/tpyrunfromnim.nim
+++ b/tests/tpyrunfromnim.nim
@@ -1,0 +1,48 @@
+# Tests for PyRun_xxx stuff
+
+import ../nimpy
+
+proc test_pyrun_string*() {.gcsafe.} =
+  
+  block:    # simple test
+    let pyCode = "print('Hello')" 
+    let pyResult =  pyRun_SimpleString(pyCode)
+    doAssert(pyResult == 0)
+
+  block:
+    let pyCode = "invalid python. Shouldn't compile"
+    let pyResult =  pyRun_SimpleString(pyCode)
+    doAssert(pyResult == -1)
+
+  block:    # multi-line input. Also sets global for next test
+    let pyCode = """
+import math
+x = math.pow(2, 3)
+    """
+    let pyResult =  pyRun_SimpleString(pyCode)
+    doAssert(pyResult == 0)
+
+  block:
+    let pyCode = """
+if x != 8:
+  raise ValueError("Expected variable 'x' to be set from previous test")
+    """
+    let pyResult =  pyRun_SimpleString(pyCode)
+    doAssert(pyResult == 0)
+
+proc test_pyrun_file*() {.gcsafe.} =
+  
+  block:
+    let fileName = "tests/pyrunfile.py"
+    let pyResult =  pyRun_SimpleFile(fileName)
+    doAssert(pyResult == 0)
+
+  block:
+    doAssertRaises(IOError):
+      let fileName = "does_not_exist.py"
+      discard  pyRun_SimpleFile(fileName)
+
+when isMainModule:
+  test_pyrun_string()
+  test_pyrun_file()
+  echo "Test complete!"


### PR DESCRIPTION
This adds support for PyRun_SimpleFile and PyRun_SimpleString for being able to run Python inside of Nim code that is not already a Python module.  

This could be used for adding Python scripting to a Nim application or using a Nim application as a customized alternative to the Python command line binary. 