### PR TITLE
one more fix for AssertionDefect not available in earlier Nim

### DIFF
--- a/nimpy.nim
+++ b/nimpy.nim
@@ -12,6 +12,9 @@ else:
   type PyObject* = ref object
     rawPyObj: PPyObject
 
+when not declared(AssertionDefect):
+  type AssertionDefect = AssertionError
+
 type
   PyNimObject {.inheritable.} = ref object
     py_extra_dont_use: PyObject_HEAD_EXTRA


### PR DESCRIPTION
Sorry for spamming with these PRs, I haven't noticed last time that `AssertionDefect` is also used in this file.