### PR TITLE
feat: put stacktraces in exceptions if possible

### DIFF
--- a/nimpy.nim
+++ b/nimpy.nim
@@ -237,7 +237,12 @@ proc updateStackBottom() {.inline.} =
 proc pythonException(e: ref Exception): PPyObject =
   let err = pyLib.PyErr_NewException(cstring("nimpy" & "." & $(e.name)), pyLib.NimPyException, nil)
   decRef err
-  pyLib.PyErr_SetString(err, cstring("Unexpected error encountered: " & e.msg))
+  let errMsg: string =
+    when compileOption("stackTrace"):
+      "Unexpected error encountered: " & e.msg & "\nstack trace: (most recent call last)\n" & e.getStackTrace()
+    else:
+      "Unexpected error encountered: " & e.msg
+  pyLib.PyErr_SetString(err, errmsg.cstring)
 
 proc iterNext(i: PPyObject): PPyObject {.cdecl.} =
   updateStackBottom()


### PR DESCRIPTION
This makes debugging exceptions and defects easier when using nimpy.
I use it in order to make testing with [hypothesis](https://hypothesis.readthedocs.io/en/latest/) more convenient, even though I recently discovered [drchaos](https://github.com/status-im/nim-drchaos) which I could for similar purposes.

What do you think? Maybe there is a better way to put a stacktrace message into a python exception though?